### PR TITLE
Feat/append or replace value

### DIFF
--- a/projects/app/src/app/app.component.ts
+++ b/projects/app/src/app/app.component.ts
@@ -7,7 +7,7 @@ import { FormControl } from '@angular/forms';
     <mat-form-field appearance="outline">
       <mat-label>Drop only .png files!</mat-label>
       <ngx-mat-dropzone>
-        <input type="file" fileInput multiple [formControl]="profileImg" accept="image/png" />
+        <input type="file" fileInput mode="replace" multiple [formControl]="profileImg" accept="image/png" />
 
         @for (image of images; track image.name) {
         <mat-chip-row (removed)="remove(image)">

--- a/projects/cdk/src/lib/coercion/boolean-coercion.spec.ts
+++ b/projects/cdk/src/lib/coercion/boolean-coercion.spec.ts
@@ -1,4 +1,4 @@
-import { coerceBoolean } from './boolean-coercion';
+import { coerceBoolean, nonNullable } from './boolean-coercion';
 
 describe('coerceBoolean', () => {
   it('should coerce undefined to false', () => {
@@ -39,5 +39,16 @@ describe('coerceBoolean', () => {
 
   it('should coerce an arbitrary string to false', () => {
     expect(coerceBoolean('random')).toBe(false);
+  });
+
+  it('filters out null values from number array', () => {
+    expect([1, null, 2, null, 3].filter(nonNullable)).toEqual([1, 2, 3]);
+  });
+
+  it('filters out null values from object array', () => {
+    expect([{ name: 'John' }, null, { name: 'Jane' }].filter(nonNullable)).toEqual([
+      { name: 'John' },
+      { name: 'Jane' },
+    ]);
   });
 });

--- a/projects/cdk/src/lib/coercion/boolean-coercion.ts
+++ b/projects/cdk/src/lib/coercion/boolean-coercion.ts
@@ -4,3 +4,8 @@ export type BooleanInput = boolean | string | number | null | undefined;
 export function coerceBoolean(value?: BooleanInput): boolean {
   return ['', '1', 'true'].includes(`${value}`);
 }
+
+/** Allows filtering `null` and `undefined` elements from arrays. */
+export function nonNullable<T>(value: T | null): value is T {
+  return value !== null && value !== undefined;
+}

--- a/projects/cdk/src/lib/dropzone/dropzone.service.ts
+++ b/projects/cdk/src/lib/dropzone/dropzone.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { nonNullable } from '../coercion';
 
 @Injectable({
   providedIn: 'root',
@@ -15,7 +16,7 @@ export class DropzoneService {
 
     const fsEntries = Array.from(event.dataTransfer?.items ?? [])
       .map((item) => this._toFileSystemEntry(item))
-      .filter((e): e is FileSystemEntry | File => e !== null)
+      .filter(nonNullable)
       .map((entry) => this._getFilesFromEntry(entry));
 
     const files: File[][] = await Promise.all(fsEntries);

--- a/projects/cdk/src/lib/file-input/file-input-value.ts
+++ b/projects/cdk/src/lib/file-input/file-input-value.ts
@@ -1,1 +1,12 @@
+/**
+ * A file input element can either be empty,
+ * hold a single file or hold multiple files.
+ */
 export type FileInputValue = File | File[] | null;
+
+/**
+ * The file input mode controls the value setting strategy.
+ * - `replace`: Replace the current value with the new value.
+ * - `append`: Append the new value to the current value if `multiple` is `true`.
+ */
+export type FileInputMode = 'replace' | 'append';

--- a/readme.md
+++ b/readme.md
@@ -178,11 +178,12 @@ Now that we have seen the minimal setup, here are some configuration options for
 
 ### FileInput directive
 
-| Property   | Description                          |
-| ---------- | ------------------------------------ |
-| `accept`   | Defines the accepted file types.     |
-| `multiple` | Allow multiple files to be selected. |
-| `disabled` | Disables any interaction.            |
+| Property   | Description                                                                            | Options                                                                                 |
+| ---------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `accept`   | Defines the accepted file types.                                                       | See [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) |
+| `mode`     | On select, either replace or append the new files. Works only with multiple attribute. | `replace` or `append`                                                                   |
+| `multiple` | Allow multiple files to be selected.                                                   | `Boolean`                                                                               |
+| `disabled` | Disables any interaction.                                                              | `Boolean`                                                                               |
 
 ### Material dropzone
 

--- a/readme.md
+++ b/readme.md
@@ -178,12 +178,12 @@ Now that we have seen the minimal setup, here are some configuration options for
 
 ### FileInput directive
 
-| Property   | Description                                                                            | Options                                                                                 |
-| ---------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `accept`   | Defines the accepted file types.                                                       | See [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) |
-| `mode`     | On select, either replace or append the new files. Works only with multiple attribute. | `replace` or `append`                                                                   |
-| `multiple` | Allow multiple files to be selected.                                                   | `Boolean`                                                                               |
-| `disabled` | Disables any interaction.                                                              | `Boolean`                                                                               |
+| Property   | Description                                                                                      | Options                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| `accept`   | Defines the accepted file types.                                                                 | See [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept) |
+| `mode`     | On select, either replace (default) or append the new files. Works only with multiple attribute. | `replace` or `append`                                                                   |
+| `multiple` | Allow multiple files to be selected.                                                             | `Boolean`                                                                               |
+| `disabled` | Disables any interaction.                                                                        | `Boolean`                                                                               |
 
 ### Material dropzone
 


### PR DESCRIPTION
With the new `mode` property on the `fileInput` directive, newly added files can be appended to the existing selection.

The default value will be `replace` which keeps the current behavior and overrides any existing selection.
If `mode=append` AND the `multiple` attribute is added, new files will be appended to the existing selection array.

Closes #52 