### PR TITLE
fix(#97): accept validator case insensitive

### DIFF
--- a/projects/cdk/src/lib/file-input/accept.service.spec.ts
+++ b/projects/cdk/src/lib/file-input/accept.service.spec.ts
@@ -25,6 +25,26 @@ describe('AcceptService', () => {
     expect(accepted).toBeFalse();
   });
 
+  it('should accept file if extension is uppercase', () => {
+    const files = [getFile('PDF')];
+
+    const acceptedUpper = service.accepts(files, '.PDF');
+    expect(acceptedUpper).toBeTrue();
+
+    const acceptedLower = service.accepts(files, '.pdf');
+    expect(acceptedLower).toBeTrue();
+  });
+
+  it('should accept file if extension is lowercase', () => {
+    const files = [getFile('pdf')];
+
+    const acceptedUpper = service.accepts(files, '.PDF');
+    expect(acceptedUpper).toBeTrue();
+
+    const acceptedLower = service.accepts(files, '.pdf');
+    expect(acceptedLower).toBeTrue();
+  });
+
   it('should filter based on MIME type', () => {
     const files = getFileList();
     const accepted = service.accepts(files, 'application/msword, application, random/MIME');

--- a/projects/cdk/src/lib/file-input/accept.service.ts
+++ b/projects/cdk/src/lib/file-input/accept.service.ts
@@ -27,7 +27,7 @@ export class AcceptService {
   }
 
   private isAcceptedByExtension(file: File, acceptedExtensions: string[]): boolean {
-    return acceptedExtensions.some((ext) => file.name.endsWith(ext));
+    return acceptedExtensions.some((ext) => file.name.toLowerCase().endsWith(ext));
   }
 
   private isAcceptedByMimeType(file: File, acceptedMimeTypes: string[]): boolean {


### PR DESCRIPTION
Fix issue where accept validator return false if file extension is uppercase. Accept validator should be case insensitive.

Closes #97.