### PR TITLE
fix: use HostListener for dragover to prevent CSP errors

### DIFF
--- a/projects/cdk/src/lib/dropzone/dropzone.component.ts
+++ b/projects/cdk/src/lib/dropzone/dropzone.component.ts
@@ -31,7 +31,6 @@ import { DropzoneService } from './dropzone.service';
     '[class.ng-dirty]': '_forwardProp("dirty")',
     '[class.ng-valid]': '_forwardProp("valid")',
     '[class.ng-invalid]': '_forwardProp("invalid")',
-    ondragover: 'event.preventDefault()',
   },
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -107,6 +106,11 @@ export class DropzoneComponent implements AfterContentInit, OnDestroy {
   _forwardProp(prop: keyof NgControl): boolean {
     return !!this.fileInputDirective?.ngControl?.[prop];
   }
+
+  @HostListener('dragover', ['$event'])
+  _onDragOver = (event: DragEvent) => {
+    event?.preventDefault();
+  };
 
   @HostListener('dragenter', ['$event'])
   _onDragEnter = (event: DragEvent) => {


### PR DESCRIPTION
With Angular's autoCSP configuration enabled, the current inline event listener for ondragover (event.preventDefault()) triggers a CSP violation.

This PR replaces the inline event listener with an @HostListener('dragover') decorator to ensure compliance with CSP restrictions while maintaining expected behavior.